### PR TITLE
Prune orphan blobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, windows-2019 ] # TODO: macos-10.15
+        os: [ ubuntu-18.04, macos-10.15, windows-2019 ]
         ghc: [ '8.10' ]
         cabal: [ '3.2' ]
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.stack-work/
 /.vscode/
 /*.sqlite3*
+/dist-newstyle/
 /stack.yaml.lock

--- a/src/lib/Monadoc/Server/Settings.hs
+++ b/src/lib/Monadoc/Server/Settings.hs
@@ -23,7 +23,6 @@ fromConfig :: Config.Config -> Warp.Settings
 fromConfig config =
   Warp.setBeforeMainLoop (beforeMainLoop config)
     . Warp.setHost (Config.host config)
-    . Warp.setLogger logger
     . Warp.setOnException onException
     . Warp.setOnExceptionResponse onExceptionResponse
     . Warp.setPort (Config.port config)
@@ -36,13 +35,6 @@ beforeMainLoop config = Console.info $ unwords
   , "port"
   , show $ Config.port config
   , "..."
-  ]
-
-logger :: Wai.Request -> Http.Status -> Maybe Integer -> IO ()
-logger request status _ = Console.info $ unwords
-  [ show $ Http.statusCode status
-  , Utf8.toString $ Wai.requestMethod request
-  , Utf8.toString $ Wai.rawPathInfo request <> Wai.rawQueryString request
   ]
 
 onException :: Maybe Wai.Request -> Exception.SomeException -> IO ()


### PR DESCRIPTION
The way the worker currently works, old index blobs will continually pile up. Rather than trying to delete them immediately when they're not used anymore, this PR makes it so the worker prunes all orphaned blobs before it runs. 

The logic for updating the index was also vastly simplified. Now the ETag is just assumed to be empty when it's missing. That should be the same as making a request without an ETag at all.

Also this PR improves the server logging. Now the log lines include the duration and allocations. Duration is given in seconds, down to millisecond precision. Allocations are given in kilobytes (really kibibytes), truncated.