### PR TITLE
Store preferred versions

### DIFF
--- a/monadoc.cabal
+++ b/monadoc.cabal
@@ -104,6 +104,8 @@ library
     Monadoc.Server.Template
     Monadoc.Type.App
     Monadoc.Type.Binary
+    Monadoc.Type.Cabal.PackageName
+    Monadoc.Type.Cabal.VersionRange
     Monadoc.Type.Config
     Monadoc.Type.ConfigResult
     Monadoc.Type.Context
@@ -172,6 +174,8 @@ test-suite test
     Monadoc.Server.TemplateSpec
     Monadoc.Type.AppSpec
     Monadoc.Type.BinarySpec
+    Monadoc.Type.Cabal.PackageNameSpec
+    Monadoc.Type.Cabal.VersionRangeSpec
     Monadoc.Type.ConfigResultSpec
     Monadoc.Type.ConfigSpec
     Monadoc.Type.ContextSpec

--- a/monadoc.cabal
+++ b/monadoc.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name: monadoc
-version: 0.2020.6.19
+version: 0.2020.6.20
 synopsis: Better Haskell documentation.
 description: Monadoc provides better Haskell documentation.
 

--- a/src/lib/Monadoc/Data/Migrations.hs
+++ b/src/lib/Monadoc/Data/Migrations.hs
@@ -41,6 +41,11 @@ migrations = Set.fromList
     \id integer not null primary key, \
     \login text not null, \
     \token text not null)"
+  , makeMigration
+    (2020, 6, 20, 8, 43, 0)
+    "create table preferred_versions (\
+    \package_name text not null primary key, \
+    \version_range text not null)"
   ]
 
 makeMigration

--- a/src/lib/Monadoc/Type/Cabal/PackageName.hs
+++ b/src/lib/Monadoc/Type/Cabal/PackageName.hs
@@ -1,0 +1,32 @@
+module Monadoc.Type.Cabal.PackageName
+  ( PackageName
+  , fromCabal
+  , fromString
+  , toCabal
+  , toString
+  )
+where
+
+import qualified Distribution.Parsec as Cabal
+import qualified Distribution.Pretty as Cabal
+import qualified Distribution.Types.PackageName as Cabal
+import qualified Monadoc.Vendor.Sql as Sql
+
+newtype PackageName
+  = PackageName Cabal.PackageName
+  deriving (Eq, Ord, Show)
+
+instance Sql.ToField PackageName where
+  toField = Sql.toField . toString
+
+fromCabal :: Cabal.PackageName -> PackageName
+fromCabal = PackageName
+
+fromString :: String -> Maybe PackageName
+fromString = fmap fromCabal . Cabal.simpleParsec
+
+toCabal :: PackageName -> Cabal.PackageName
+toCabal (PackageName cabal) = cabal
+
+toString :: PackageName -> String
+toString = Cabal.prettyShow . toCabal

--- a/src/lib/Monadoc/Type/Cabal/VersionRange.hs
+++ b/src/lib/Monadoc/Type/Cabal/VersionRange.hs
@@ -1,0 +1,32 @@
+module Monadoc.Type.Cabal.VersionRange
+  ( VersionRange
+  , fromCabal
+  , fromString
+  , toCabal
+  , toString
+  )
+where
+
+import qualified Distribution.Parsec as Cabal
+import qualified Distribution.Pretty as Cabal
+import qualified Distribution.Types.VersionRange as Cabal
+import qualified Monadoc.Vendor.Sql as Sql
+
+newtype VersionRange
+  = VersionRange Cabal.VersionRange
+  deriving (Eq, Show)
+
+instance Sql.ToField VersionRange where
+  toField = Sql.toField . toString
+
+fromCabal :: Cabal.VersionRange -> VersionRange
+fromCabal = VersionRange
+
+fromString :: String -> Maybe VersionRange
+fromString = fmap fromCabal . Cabal.simpleParsec
+
+toCabal :: VersionRange -> Cabal.VersionRange
+toCabal (VersionRange cabal) = cabal
+
+toString :: VersionRange -> String
+toString = Cabal.prettyShow . toCabal

--- a/src/test/Main.hs
+++ b/src/test/Main.hs
@@ -30,6 +30,8 @@ import qualified Monadoc.Server.SettingsSpec
 import qualified Monadoc.Server.TemplateSpec
 import qualified Monadoc.Type.AppSpec
 import qualified Monadoc.Type.BinarySpec
+import qualified Monadoc.Type.Cabal.PackageNameSpec
+import qualified Monadoc.Type.Cabal.VersionRangeSpec
 import qualified Monadoc.Type.ConfigResultSpec
 import qualified Monadoc.Type.ConfigSpec
 import qualified Monadoc.Type.ContextSpec
@@ -87,6 +89,8 @@ main = Test.hspec $ do
   Monadoc.Server.TemplateSpec.spec
   Monadoc.Type.AppSpec.spec
   Monadoc.Type.BinarySpec.spec
+  Monadoc.Type.Cabal.PackageNameSpec.spec
+  Monadoc.Type.Cabal.VersionRangeSpec.spec
   Monadoc.Type.ConfigResultSpec.spec
   Monadoc.Type.ConfigSpec.spec
   Monadoc.Type.ContextSpec.spec

--- a/src/test/Monadoc/Type/Cabal/PackageNameSpec.hs
+++ b/src/test/Monadoc/Type/Cabal/PackageNameSpec.hs
@@ -1,0 +1,23 @@
+module Monadoc.Type.Cabal.PackageNameSpec
+  ( spec
+  )
+where
+
+import qualified Data.Maybe as Maybe
+import qualified Monadoc.Type.Cabal.PackageName as PackageName
+import qualified Test
+
+spec :: Test.Spec
+spec = Test.describe "Monadoc.Type.Cabal.PackageName" $ do
+
+  Test.describe "fromString" $ do
+
+    Test.it "works" $ do
+      PackageName.fromString "some-package" `Test.shouldSatisfy` Maybe.isJust
+
+  Test.describe "toString" $ do
+
+    Test.it "works" $ do
+      let string = "some-package"
+      Just packageName <- pure $ PackageName.fromString string
+      PackageName.toString packageName `Test.shouldBe` string

--- a/src/test/Monadoc/Type/Cabal/VersionRangeSpec.hs
+++ b/src/test/Monadoc/Type/Cabal/VersionRangeSpec.hs
@@ -1,0 +1,23 @@
+module Monadoc.Type.Cabal.VersionRangeSpec
+  ( spec
+  )
+where
+
+import qualified Data.Maybe as Maybe
+import qualified Monadoc.Type.Cabal.VersionRange as VersionRange
+import qualified Test
+
+spec :: Test.Spec
+spec = Test.describe "Monadoc.Type.Cabal.VersionRange" $ do
+
+  Test.describe "fromString" $ do
+
+    Test.it "works" $ do
+      VersionRange.fromString "> 0" `Test.shouldSatisfy` Maybe.isJust
+
+  Test.describe "toString" $ do
+
+    Test.it "works" $ do
+      let string = ">0"
+      Just versionRange <- pure $ VersionRange.fromString string
+      VersionRange.toString versionRange `Test.shouldBe` string


### PR DESCRIPTION
Previously I was ignoring the `preferred-versions` files. Now I'm parsing them and storing the result. Note that the database update happens all at once at the end rather than as we go along. This is necessary because the preferred versions are append-only like the rest of the index. 

I also added more logging to the worker. The goal is to get better visibility into what's going on when it runs on AWS. 