### PR TITLE
Investigate SQLite performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.stack-work/
 /.vscode/
 /*.sqlite3*
+/blobs/
 /dist-newstyle/
 /stack.yaml.lock

--- a/aws/cloud-formation.yaml
+++ b/aws/cloud-formation.yaml
@@ -220,7 +220,7 @@ Resources:
               - monadoc
               - !Sub --client-id=${ClientId}
               - !Sub --client-secret=${ClientSecret}
-              - --database=/efs/monadoc.sqlite3
+              - --database=/efs/monadoc-attempt-1.sqlite3
               - !Sub --discord-url=${DiscordUrl}
               - --host=*
               - !Sub --port=${Port}

--- a/aws/cloud-formation.yaml
+++ b/aws/cloud-formation.yaml
@@ -340,7 +340,7 @@ Resources:
     Type: AWS::ECS::Service
     Properties:
       Cluster: !Ref Cluster
-      DesiredCount: 1
+      DesiredCount: 0 # TODO: 1
       LaunchType: FARGATE
       LoadBalancers:
         - ContainerName: !Sub ${AWS::StackName}-custom-container

--- a/monadoc.cabal
+++ b/monadoc.cabal
@@ -29,6 +29,7 @@ common library
     , containers >= 0.6.2 && < 0.7
     , cookie >= 0.4.5 && < 0.5
     , cryptonite >= 0.26 && < 0.27
+    , directory >= 1.3.6 && < 1.4
     , exceptions >= 0.10.4 && < 0.11
     , filepath >= 1.4.2 && < 1.5
     , ghc >= 8.10.1 && < 8.11

--- a/src/lib/Monadoc.hs
+++ b/src/lib/Monadoc.hs
@@ -5,7 +5,6 @@ module Monadoc
   )
 where
 
-import qualified Control.Concurrent as Concurrent
 import qualified Control.Monad as Monad
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Maybe as Maybe
@@ -99,8 +98,9 @@ argumentsToConfigResult name arguments =
 configToContext :: Config.Config -> IO (Context.Context ())
 configToContext config = do
   manager <- Tls.newTlsManager
-  let database = Config.database config
-  maxResources <- if isInMemory database then pure 1 else getMaxResources
+  let
+    database = Config.database config
+    maxResources = 1
   pool <- Pool.createPool
     (Sql.open database)
     Sql.close
@@ -119,12 +119,3 @@ stripeCount = 1
 
 idleTime :: Time.NominalDiffTime
 idleTime = 60
-
-getMaxResources :: IO Int
-getMaxResources = fmap (max 1) Concurrent.getNumCapabilities
-
-isInMemory :: FilePath -> Bool
-isInMemory database = case database of
-  "" -> True
-  ":memory:" -> True
-  _ -> False

--- a/src/lib/Monadoc/Main.hs
+++ b/src/lib/Monadoc/Main.hs
@@ -43,6 +43,7 @@ runMigrations :: Stack.HasCallStack => App.App request ()
 runMigrations = do
   Console.info "Running migrations ..."
   App.withConnection $ \connection -> Trans.lift $ do
+    Sql.execute_ connection "pragma journal_mode = wal"
     Sql.execute_
       connection
       "create table if not exists migrations \

--- a/src/lib/Monadoc/Main.hs
+++ b/src/lib/Monadoc/Main.hs
@@ -43,7 +43,6 @@ runMigrations :: Stack.HasCallStack => App.App request ()
 runMigrations = do
   Console.info "Running migrations ..."
   App.withConnection $ \connection -> Trans.lift $ do
-    Sql.execute_ connection "pragma journal_mode = wal"
     Sql.execute_
       connection
       "create table if not exists migrations \


### PR DESCRIPTION
Following on from #13 and #14. Things to try:

- [x] Limiting pool to one connection. 
- [x] Running the worker by itself. 
- [x] Disabling write ahead logging. 
- [x] Using a non-EFS SQLite file. 
- [x] Giving the instance more resources. 
- [x] Giving the EFS more resources. 
- [x] Storing blobs outside of SQLite. 
- [ ] Running WAL check points. 