### PR TITLE
Small cleanup

### DIFF
--- a/aws/cloud-formation.yaml
+++ b/aws/cloud-formation.yaml
@@ -138,7 +138,7 @@ Resources:
         - Fn::GetAZs: !Ref AWS::Region
       IamInstanceProfile: !Ref InstanceProfile
       ImageId: !Ref AmiId
-      InstanceType: t3a.micro
+      InstanceType: t3a.small
       SecurityGroupIds:
         - !Ref SecurityGroup
       SubnetId: !Ref Subnet1
@@ -343,7 +343,7 @@ Resources:
       Cpu: 1024
       ExecutionRoleArn: !Ref TaskRole
       Family: !Sub ${AWS::StackName}-task-definition
-      Memory: 480
+      Memory: 980
       NetworkMode: bridge
       Volumes:
         - Host:

--- a/monadoc.cabal
+++ b/monadoc.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name: monadoc
-version: 0.2020.6.28
+version: 0.2020.6.29
 synopsis: Better Haskell documentation.
 description: Monadoc provides better Haskell documentation.
 

--- a/src/lib/Monadoc/Worker/Main.hs
+++ b/src/lib/Monadoc/Worker/Main.hs
@@ -61,6 +61,7 @@ sendExceptionToDiscord :: Exception.SomeException -> App.App request ()
 sendExceptionToDiscord exception = do
   context <- Reader.ask
   Trans.lift $ Settings.sendExceptionToDiscord context exception
+  Exception.throwM exception
 
 pruneBlobs :: App.App request ()
 pruneBlobs = do


### PR DESCRIPTION
- Upgrades instance from t3a.micro to t3a.small. This doubles the available memory.
  - As a result, this PR doubles the memory allocated to the tasks.
  - I did this because for some reason the task was running out of memory on startup. Haven't figured out why yet. 
- Re-throws exceptions from the worker so that the entire task will be brought down (and then restarted by ECS). 