### PR TITLE
Attempt to fix GHC in Docker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,6 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: monadoc-ubuntu-18.04-${{ github.sha }}-ghc
-          path: docker
       - run: tar xzf ghc.tgz -C docker
       - uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           path: docker/monadoc*
           name: monadoc-${{ matrix.os }}-${{ github.sha }}
       - if: matrix.os == 'ubuntu-18.04'
-        run: tar czf ghc.tgz -C /opt/ghc/8.10/lib ghc-8.10.1
+        run: tar czf ghc.tgz -C /opt/ghc/8.10.1/lib ghc-8.10.1
       - if: matrix.os == 'ubuntu-18.04'
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,11 @@ jobs:
         with:
           path: docker/monadoc*
           name: monadoc-${{ matrix.os }}-${{ github.sha }}
+      - run: tar czf ghc.tgz -C /opt/ghc/8.10/lib ghc-8.10.1
+      - uses: actions/upload-artifact@v2
+        with:
+          path: docker/monadoc*
+          name: monadoc-${{ matrix.os }}-${{ github.sha }}-ghc
 
   push:
     needs: build
@@ -54,6 +59,11 @@ jobs:
           path: docker
       - run: chmod +x docker/monadoc
       - run: cp --recursive data docker
+      - uses: actions/download-artifact@v2
+        with:
+          name: monadoc-ubuntu-18.04-${{ github.sha }}-ghc
+          path: docker
+      - run: tar xzf ghc.tgz -C docker
       - uses: docker/build-push-action@v1
         with:
           username: taylorfausak

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,10 +42,12 @@ jobs:
         with:
           path: docker/monadoc*
           name: monadoc-${{ matrix.os }}-${{ github.sha }}
-      - run: tar czf ghc.tgz -C /opt/ghc/8.10/lib ghc-8.10.1
-      - uses: actions/upload-artifact@v2
+      - if: matrix.os == 'ubuntu-18.04'
+        run: tar czf ghc.tgz -C /opt/ghc/8.10/lib ghc-8.10.1
+      - if: matrix.os == 'ubuntu-18.04'
+        uses: actions/upload-artifact@v2
         with:
-          path: docker/monadoc*
+          path: ghc.tgz
           name: monadoc-${{ matrix.os }}-${{ github.sha }}-ghc
 
   push:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,13 +19,17 @@ jobs:
         cabal: [ '3.2' ]
     runs-on: ${{ matrix.os }}
     steps:
+
       - uses: actions/checkout@v2
+
       - id: setup-haskell
         uses: actions/setup-haskell@v1.1
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
+
       - run: cabal freeze
+
       - uses: actions/cache@v2
         with:
           path: ${{ steps.setup-haskell.outputs.cabal-store  }}
@@ -33,39 +37,27 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-${{ matrix.ghc }}-${{ matrix.cabal }}-
             ${{ matrix.os }}-${{ matrix.ghc }}-
+
       - run: runghc src/script/set-commit-hash.hs src/lib/Monadoc/Data/Commit.hs ${{ github.sha }}
+
       - run: cabal build --only-dependencies
+
       - run: cabal build
+
       - run: cabal test --test-show-details direct
+
       - run: cabal install --install-method copy --installdir docker
+
       - uses: actions/upload-artifact@v2
         with:
           path: docker/monadoc*
           name: monadoc-${{ matrix.os }}-${{ github.sha }}
-      - if: matrix.os == 'ubuntu-18.04'
-        run: tar czf ghc.tgz -C /opt/ghc/8.10.1/lib ghc-8.10.1
-      - if: matrix.os == 'ubuntu-18.04'
-        uses: actions/upload-artifact@v2
-        with:
-          path: ghc.tgz
-          name: monadoc-${{ matrix.os }}-${{ github.sha }}-ghc
 
-  push:
-    needs: build
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          name: monadoc-ubuntu-18.04-${{ github.sha }}
-          path: docker
-      - run: chmod +x docker/monadoc
-      - run: cp --recursive data docker
-      - uses: actions/download-artifact@v2
-        with:
-          name: monadoc-ubuntu-18.04-${{ github.sha }}-ghc
-      - run: tar xzf ghc.tgz -C docker
-      - uses: docker/build-push-action@v1
+      - if: matrix.os == 'ubuntu-18.04'
+        run: cp --recursive data /opt/ghc/8.10.1/lib/ghc-8.10.1 docker
+
+      - if: matrix.os == 'ubuntu-18.04'
+        uses: docker/build-push-action@v1
         with:
           username: taylorfausak
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -75,20 +67,24 @@ jobs:
 
   deploy:
     if: github.ref == 'refs/heads/main'
-    needs: push
+    needs: build
     runs-on: ubuntu-18.04
     steps:
+
       - run: >
           curl
           --header 'Content-Type: application/json'
           --data '{ "content": "Deploying commit `${{ github.sha }}` ..." }'
           '${{ secrets.DISCORD_URL }}'
+
       - uses: actions/checkout@v2
+
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
+
       - uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:
           name: monadoc
@@ -96,18 +92,21 @@ jobs:
           parameter-overrides: ClientSecret=${{ secrets.CLIENT_SECRET }},DiscordUrl=${{ secrets.DISCORD_URL }},TagName=${{ github.sha }}
           no-fail-on-empty-changeset: '1'
           capabilities: CAPABILITY_NAMED_IAM
+
       - if: success()
         run: >
           curl
           --header 'Content-Type: application/json'
           --data '{ "content": "Successfully deployed `${{ github.sha }}`." }'
           '${{ secrets.DISCORD_URL }}'
+
       - if: failure()
         run: >
           curl
           --header 'Content-Type: application/json'
           --data '{ "content": "Failed to deploy `${{ github.sha }}`!" }'
           '${{ secrets.DISCORD_URL }}'
+
       - if: cancelled()
         run: >
           curl

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:18.04
 RUN apt-get update && apt-get install --assume-yes ca-certificates
 COPY data /opt/monadoc/data
+COPY ghc-8.10.1 /opt/ghc/8.10/lib/ghc-8.10.1
 ENV monadoc_datadir /opt/monadoc
 COPY monadoc /usr/local/bin/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 RUN apt-get update && apt-get install --assume-yes ca-certificates
 COPY data /opt/monadoc/data
-COPY ghc-8.10.1 /opt/ghc/8.10/lib/ghc-8.10.1
+COPY ghc-8.10.1 /opt/ghc/8.10.1/lib/ghc-8.10.1
 ENV monadoc_datadir /opt/monadoc
 COPY monadoc /usr/local/bin/

--- a/monadoc.cabal
+++ b/monadoc.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name: monadoc
-version: 0.2020.8.15
+version: 0.2020.8.16
 synopsis: Better Haskell documentation.
 description: Monadoc provides better Haskell documentation.
 


### PR DESCRIPTION
As I should've expected, parsing with GHC fails in Docker. This is the error I see:

> Missing file: /opt/ghc/8.10.1/lib/ghc-8.10.1/settings

The `ghc-paths` package tells you where to find GHC's various files on the build machine, but I wasn't copying those files over to the container image. This PR attempts to fix that, although I suspect it may take a couple tries. 