### PR TITLE
Handle CPP

### DIFF
--- a/monadoc.cabal
+++ b/monadoc.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name: monadoc
-version: 0.2020.8.16
+version: 0.2020.8.21
 synopsis: Better Haskell documentation.
 description: Monadoc provides better Haskell documentation.
 

--- a/monadoc.cabal
+++ b/monadoc.cabal
@@ -28,6 +28,7 @@ common library
     , Cabal >= 3.2.0 && < 3.3
     , containers >= 0.6.2 && < 0.7
     , cookie >= 0.4.5 && < 0.5
+    , cpphs >= 1.20.9 && < 1.21
     , cryptonite >= 0.26 && < 0.27
     , exceptions >= 0.10.4 && < 0.11
     , filepath >= 1.4.2 && < 1.5

--- a/src/lib/Monadoc/Data/Migrations.hs
+++ b/src/lib/Monadoc/Data/Migrations.hs
@@ -81,10 +81,10 @@ migrations = Set.fromList
     \parsed boolean not null default false, \
     \unique (package, version, revision, module))"
   , makeMigration
-    (2020, 8, 18, 7, 44, 0)
+    (2020, 8, 19, 22, 9, 0)
     "delete from processed_files where path like 'd/%'"
   , makeMigration
-    (2020, 8, 18, 7, 45, 0)
+    (2020, 8, 19, 22, 10, 0)
     "update exposed_modules set parsed = false"
   ]
 

--- a/src/lib/Monadoc/Data/Migrations.hs
+++ b/src/lib/Monadoc/Data/Migrations.hs
@@ -71,9 +71,6 @@ migrations = Set.fromList
   , makeMigration (2020, 8, 15, 9, 50, 0) "drop table exposed_modules"
   , makeMigration (2020, 8, 15, 9, 51, 0) "drop table exposed_modules2"
   , makeMigration
-    (2020, 8, 15, 9, 52, 0)
-    "delete from processed_files where path like 'd/%'"
-  , makeMigration
     (2020, 8, 15, 9, 53, 0)
     "create table exposed_modules (\
     \package text not null, \
@@ -83,6 +80,12 @@ migrations = Set.fromList
     \file text, \
     \parsed boolean not null default false, \
     \unique (package, version, revision, module))"
+  , makeMigration
+    (2020, 8, 18, 7, 44, 0)
+    "delete from processed_files where path like 'd/%'"
+  , makeMigration
+    (2020, 8, 18, 7, 45, 0)
+    "update exposed_modules set parsed = false"
   ]
 
 makeMigration

--- a/src/lib/Monadoc/Ghc.hs
+++ b/src/lib/Monadoc/Ghc.hs
@@ -2,6 +2,7 @@ module Monadoc.Ghc where
 
 import qualified Bag
 import qualified Control.Exception
+import qualified Control.Monad
 import qualified Data.ByteString
 import qualified Data.Function
 import qualified Data.Text
@@ -62,6 +63,7 @@ parse extensions filePath byteString = Control.Exception.handle handler $ do
   string2 <- if DynFlags.xopt GHC.LanguageExtensions.Type.Cpp dynFlags3
     then Cpp.runCpphs cpphsOptions filePath string1
     else pure string1
+  Control.Monad.void . Control.Exception.evaluate $ length string2
   let stringBuffer2 = StringBuffer.stringToStringBuffer string2
   let fastString = FastString.mkFastString filePath
   let realSrcLoc = SrcLoc.mkRealSrcLoc fastString 1 1

--- a/src/lib/Monadoc/Ghc.hs
+++ b/src/lib/Monadoc/Ghc.hs
@@ -55,16 +55,17 @@ parse extensions filePath byteString = Control.Exception.handle handler $ do
       (DynFlags.gopt_set dynFlags1 DynFlags.Opt_KeepRawTokenStream)
       extensions
   let text = Utf8.toText byteString
-  let originalString = Data.Text.unpack text
-  string <- if DynFlags.xopt GHC.LanguageExtensions.Type.Cpp dynFlags2
-    then Cpp.runCpphs cpphsOptions filePath originalString
-    else pure originalString
-  let stringBuffer = StringBuffer.stringToStringBuffer string
-  let locatedStrings = HeaderInfo.getOptions dynFlags2 stringBuffer filePath
+  let string1 = Data.Text.unpack text
+  let stringBuffer1 = StringBuffer.stringToStringBuffer string1
+  let locatedStrings = HeaderInfo.getOptions dynFlags2 stringBuffer1 filePath
   (dynFlags3, _, _) <- DynFlags.parseDynamicFilePragma dynFlags2 locatedStrings
+  string2 <- if DynFlags.xopt GHC.LanguageExtensions.Type.Cpp dynFlags3
+    then Cpp.runCpphs cpphsOptions filePath string1
+    else pure string1
+  let stringBuffer2 = StringBuffer.stringToStringBuffer string2
   let fastString = FastString.mkFastString filePath
   let realSrcLoc = SrcLoc.mkRealSrcLoc fastString 1 1
-  let pState1 = Lexer.mkPState dynFlags3 stringBuffer realSrcLoc
+  let pState1 = Lexer.mkPState dynFlags3 stringBuffer2 realSrcLoc
   pure $ case Lexer.unP Parser.parseModule pState1 of
     Lexer.PFailed pState2 ->
       Left . Errors . snd $ Lexer.getMessages pState2 dynFlags3

--- a/src/lib/Monadoc/Type/Cabal/Version.hs
+++ b/src/lib/Monadoc/Type/Cabal/Version.hs
@@ -1,6 +1,7 @@
 module Monadoc.Type.Cabal.Version where
 
 import qualified Data.List as List
+import qualified Distribution.Parsec as Cabal
 import qualified Distribution.Types.Version as Cabal
 import qualified Monadoc.Vendor.Sql as Sql
 
@@ -11,6 +12,9 @@ instance Sql.ToField Version where
 
 fromCabal :: Cabal.Version -> Version
 fromCabal = Version
+
+fromString :: String -> Maybe Version
+fromString = fmap fromCabal . Cabal.simpleParsec
 
 toCabal :: Version -> Cabal.Version
 toCabal (Version cabal) = cabal

--- a/src/test/Monadoc/GhcSpec.hs
+++ b/src/test/Monadoc/GhcSpec.hs
@@ -47,3 +47,18 @@ spec = describe "Monadoc.Ghc" $ do
         \module M where\n\
         \#endif"
       result `shouldSatisfy` Either.isRight
+
+    it "works with CPP pragma" $ do
+      result <- Ghc.parse [] "" "{-# language CPP #-}\n#"
+      result `shouldSatisfy` Either.isRight
+
+    it "does not throw impure CPP errors" $ do
+      result <- Ghc.parse [(True, Ext.Cpp)] "" "#error"
+      result `shouldSatisfy` Either.isLeft
+
+    it "works with implied extensions" $ do
+      result <- Ghc.parse
+        [(True, Ext.RankNTypes)]
+        ""
+        "f :: forall a . a -> a\nf a = a"
+      result `shouldSatisfy` Either.isRight

--- a/src/test/Monadoc/GhcSpec.hs
+++ b/src/test/Monadoc/GhcSpec.hs
@@ -36,3 +36,14 @@ spec = describe "Monadoc.Ghc" $ do
         ""
         "data X = X {}"
       result `shouldSatisfy` Either.isLeft
+
+    it "works with CPP" $ do
+      result <- Ghc.parse
+        [(True, Ext.Cpp)]
+        ""
+        "#ifdef NOT_DEFINED\n\
+        \invalid# = True\n\
+        \#else\n\
+        \module M where\n\
+        \#endif"
+      result `shouldSatisfy` Either.isRight


### PR DESCRIPTION
I should have expected this problem while working on #23. Using GHC as a library doesn't handle CPP in the way you might expect. Since CPP is an external program, GHC appears to identify the language extension and change how it parses, but it doesn't actually succeed. It seemed to me like the easiest way out was to use `cpphs` to run CPP when necessary. A couple things though:

- It's not clear when to run CPP. GHC needs to semi-parse the file to find language extensions. Are you supposed to run CPP before or after that? After would make sense because you can do `{-# language CPP #-}`, but the language pragmas themselves could be behind CPP so who knows. Some experimentation is in order.

- Various CPP options from the Cabal file need to be passed through. Any defined variables need to be set up. And any actual options need to be parsed and applied, which might be tricky. Not every package uses (or can use?) `cpphs`, so options may need to be converted from GCC or Clang into `cpphs`. Sounds like fun. 

In spite of the above caveats, I feel reasonably confident saying that many of the parse failures will be fixed by these changes. 